### PR TITLE
Add a basic table shortcode

### DIFF
--- a/layouts/shortcodes/table.html
+++ b/layouts/shortcodes/table.html
@@ -1,0 +1,19 @@
+{{ $htmlTable := .Inner | markdownify }}
+
+{{ $tableClass := .Get "table-class" }}
+{{ $thClass := .Get "th-class" }}
+{{ $tdClass := .Get "td-class" }}
+
+{{ $oldTable := "<table>" }}
+{{ $newTable := printf "<table class=\"%s\">" $tableClass }}
+{{ $htmlTable := replace $htmlTable $oldTable $newTable }}
+
+{{ $oldTh := "<th>" }}
+{{ $newTh := printf "<th class=\"%s\">" $thClass }}
+{{ $htmlTable := replace $htmlTable $oldTh $newTh }}
+
+{{ $oldTd := "<td>" }}
+{{ $newTd := printf "<td class=\"%s\">" $tdClass }}
+{{ $htmlTable := replace $htmlTable $oldTd $newTd }}
+
+{{ $htmlTable | safeHTML }}


### PR DESCRIPTION
This adds a basic table shortcode. Here's an example of how to use it:

```
{{<table table-class="f6 w-100 mw8 center"
         th-class="fw6 bb b--black-20 tl pb3 pr3"
         td-class="pv3 pr3 bb b--black-20">}}
| Issue | How to Report| Phone |
|---|---|---|
| Abandon Vehicle  | [Web](http://sanjose.custhelp.com/), [iOS](https://apps.apple.com/us/app/my-san-jose-a-newway/id1231429879), [Android](https://play.google.com/store/apps/details?id=com.astcorporation.three11&hl=en) |  408-535-3500 |
|  Graffiti | [Web](http://sanjose.custhelp.com/), [iOS](https://apps.apple.com/us/app/my-san-jose-a-newway/id1231429879), [Android](https://play.google.com/store/apps/details?id=com.astcorporation.three11&hl=en) |  408-535-3500 |
{{</table>}}
```